### PR TITLE
Use env API URL in Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Create a `.env` file in `server/`:
 OPENAI_API_KEY=your_openai_key_here
 ```
 
+Create a `.env` file in `client/` (or copy `client/.env.example`) and set the API base URL if needed:
+
+```env
+# URL where the Express server is running
+VITE_API_URL=http://localhost:5050
+```
+
 Also ensure you have a valid `firebase.ts` config in `client/src/`, but **do not commit it**.
 
 ### 4. Run the App

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,3 @@
+# Base URL for API requests
+# Uncomment and adjust if your backend runs elsewhere
+VITE_API_URL=http://localhost:5050

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ interface DayPlan {
 }
 
 const Dashboard = () => {
+  const API_BASE = import.meta.env.VITE_API_URL || "";
   const [input, setInput] = useState("");
   const [goals, setGoals] = useState("");
   const [weight, setWeight] = useState("");
@@ -29,7 +30,7 @@ const Dashboard = () => {
   useEffect(() => {
     const fetchXP = async () => {
       try {
-        const res = await fetch("http://localhost:5050/api/user-xp");
+        const res = await fetch(`${API_BASE}/api/user-xp`);
         const data = await res.json();
         setCompletedCount(data.xp);
         setLevel(Math.floor(data.xp / 10) + 1);
@@ -48,7 +49,7 @@ const Dashboard = () => {
       setRoutine(updated);
 
       try {
-        const res = await fetch("http://localhost:5050/api/increment-xp", {
+        const res = await fetch(`${API_BASE}/api/increment-xp`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ amount: 1 }),
@@ -114,7 +115,7 @@ Do not ask for additional information. Format the output using "Day 1:", "Day 2:
 "1. Exercise Name - Description of sets, reps, or duration."`;
 
     try {
-      const res = await fetch("http://localhost:5050/api/ask", {
+      const res = await fetch(`${API_BASE}/api/ask`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: fullPrompt }),


### PR DESCRIPTION
## Summary
- add example env variable for the client's API base URL
- allow Dashboard requests to use VITE_API_URL
- document the new variable in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844839641088321bd1a2084193ddf40