### PR TITLE
Fix server start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Also ensure you have a valid `firebase.ts` config in `client/src/`, but **do not
 
 ```bash
 # Terminal 1: Start the server
-cd server
-node index.js
+cd server/
+npm start
 
 # Terminal 2: Start the client
 cd client


### PR DESCRIPTION
## Summary
- fix README commands to use `npm start` for the server
- show changing into `server/` before running the command

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844838c4b40832180598900b408aa8c