### PR TITLE
Add basic XP unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ npm run dev
 
 Visit: [http://localhost:5173](http://localhost:5173)
 
+### 5. Run Tests
+
+Server unit tests use Node's built-in runner:
+
+```bash
+cd server
+npm test
+```
+
 ---
 
 ## 🧪 API Routes

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.0",

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import { OpenAI } from "openai";
+import { getXP, incrementXP } from "./xp.js";
 
 dotenv.config();
 const app = express();
@@ -10,8 +11,6 @@ app.use(express.json());
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-// ==== In-Memory XP Store (for now) ====
-let userXP = 0;
 
 // === Generate Workout Plan ===
 app.post("/api/ask", async (req, res) => {
@@ -43,18 +42,18 @@ app.post("/api/ask", async (req, res) => {
 
 // === Get XP ===
 app.get("/api/user-xp", (req, res) => {
-  res.json({ xp: userXP });
+  res.json({ xp: getXP() });
 });
 
 // === Increment XP ===
 app.post("/api/increment-xp", (req, res) => {
   const { amount } = req.body;
-  if (typeof amount !== "number" || amount <= 0) {
-    return res.status(400).json({ error: "Invalid XP amount" });
+  try {
+    const xp = incrementXP(amount);
+    res.json({ xp });
+  } catch {
+    res.status(400).json({ error: "Invalid XP amount" });
   }
-
-  userXP += amount;
-  res.json({ xp: userXP });
 });
 
 const PORT = process.env.PORT || 5050;

--- a/server/test/xp.test.js
+++ b/server/test/xp.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { test, beforeEach } from 'node:test';
+import { getXP, incrementXP, resetXP } from '../xp.js';
+
+beforeEach(() => {
+  resetXP();
+});
+
+test('initial XP is 0', () => {
+  assert.equal(getXP(), 0);
+});
+
+test('incrementXP adds to total', () => {
+  const xp = incrementXP(5);
+  assert.equal(xp, 5);
+  assert.equal(getXP(), 5);
+});
+
+test('incrementXP rejects invalid amount', () => {
+  assert.throws(() => incrementXP(-1), /Invalid XP amount/);
+  assert.equal(getXP(), 0);
+});

--- a/server/xp.js
+++ b/server/xp.js
@@ -1,0 +1,17 @@
+let userXP = 0;
+
+export function getXP() {
+  return userXP;
+}
+
+export function incrementXP(amount) {
+  if (typeof amount !== 'number' || amount <= 0) {
+    throw new Error('Invalid XP amount');
+  }
+  userXP += amount;
+  return userXP;
+}
+
+export function resetXP() {
+  userXP = 0;
+}


### PR DESCRIPTION
## Summary
- add an `xp` module for handling user XP state
- refactor server to use the new `xp` module
- create tests for the XP logic using Node's built-in test runner
- document how to run the tests in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448598bf408321990f28241585c8dc